### PR TITLE
Fix numpy error which causes crash

### DIFF
--- a/tasks/interactive_idino_m2m.py
+++ b/tasks/interactive_idino_m2m.py
@@ -83,7 +83,7 @@ def interactive_infer_image(model, image,all_classes,all_parts, thresh,text_size
         areas.append(area)
         mask,_=remove_small_regions(mask,int(hole_scale),mode="holes")
         mask,_=remove_small_regions(mask,int(island_scale),mode="islands")
-        mask=(mask).astype(np.float)
+        mask=(mask).astype(float)
         out_txt = texts
         visual = Visualizer(image_ori, metadata=metadata)
         color=[0.,0.,1.0]

--- a/tasks/interactive_predictor.py
+++ b/tasks/interactive_predictor.py
@@ -85,7 +85,7 @@ class SemanticSAMPredictor:
             areas.append(area)
             mask, _ = self.remove_small_regions(mask, int(self.hole_scale), mode="holes")
             mask, _ = self.remove_small_regions(mask, int(self.island_scale), mode="islands")
-            mask = (mask).astype(np.float)
+            mask = (mask).astype(float)
             out_txt = texts
             visual = Visualizer(image_ori, metadata=metadata)
             color = [0., 0., 1.0]


### PR DESCRIPTION
Fixes fatal error which occurs when running the interactive demo by changing `np.float` to `float` (they are identical: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations). Feel free to change to `np.float64` if preferred.